### PR TITLE
Adjust benchmark code to new `igc` dependency

### DIFF
--- a/benches/olc_classic.rs
+++ b/benches/olc_classic.rs
@@ -7,17 +7,21 @@ extern crate igc;
 use criterion::Criterion;
 use aeroscore::olc;
 
-struct Point(igc::Fix);
+struct Point {
+    latitude: f64,
+    longitude: f64,
+    altitude: i16,
+}
 
 impl olc::Point for Point {
     fn latitude(&self) -> f64 {
-        self.0.latitude
+        self.latitude
     }
     fn longitude(&self) -> f64 {
-        self.0.longitude
+        self.longitude
     }
     fn altitude(&self) -> i16 {
-        self.0.altitude_gps
+        self.altitude
     }
 }
 
@@ -26,7 +30,12 @@ fn criterion_benchmark(c: &mut Criterion) {
         let fixes = include_str!("../tests/fixtures/2017-08-14-fla-6ng-01.igc")
             .lines()
             .filter(|l| l.starts_with('B'))
-            .map(|line| Point(igc::parse_fix(line)))
+            .filter_map(|line| igc::records::BRecord::parse(&line).ok()
+                .map(|record| Point {
+                    latitude: record.pos.lat.into(),
+                    longitude: record.pos.lon.into(),
+                    altitude: record.gps_alt,
+                }))
             .collect::<Vec<_>>();
 
         olc::optimize(&fixes).unwrap()


### PR DESCRIPTION
It looks like our CI is actually not building the `cargo bench` code, so this was undiscovered when writing 27902d6ac0e2a0cfc012d858ac297ef4f1560f69 🙈 